### PR TITLE
fix: work with newer Projen versions

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -112,6 +112,7 @@
     },
     {
       "name": "projen",
+      "version": "0.58.16",
       "type": "build"
     },
     {
@@ -134,6 +135,7 @@
     },
     {
       "name": "typescript",
+      "version": "4.7.4",
       "type": "build"
     },
     {
@@ -178,6 +180,7 @@
     },
     {
       "name": "projen",
+      "version": ">0.58.15",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -33,7 +33,8 @@ const project = new TypeScriptProject({
   ...npmReleaser.nodeProjectOptions(),
   ...Recommended.defaultProjectOptions,
   description: "A collection of cool projen components",
-  peerDeps: ["projen"],
+  typescriptVersion: "4.7.4",
+  peerDeps: ["projen@>0.58.15"],
   bundledDeps: [
     "merge",
     "traverse",

--- a/package.json
+++ b/package.json
@@ -61,15 +61,15 @@
     "jest-junit": "^13",
     "json-schema": "^0.4.0",
     "prettier": "^2.6.2",
-    "projen": "^0.58.15",
+    "projen": "0.58.16",
     "standard-version": "^9",
     "ts-jest": "^27",
-    "ts-node": "^10.8.0",
+    "ts-node": "^10.8.1",
     "typedoc": "*",
-    "typescript": "^4.6.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
-    "projen": "^0.58.15"
+    "projen": ">0.58.15"
   },
   "dependencies": {
     "@commitlint/cli": "^16.3.0",
@@ -166,6 +166,7 @@
   },
   "types": "lib/index.d.ts",
   "contributors": [
+    "Juho Saarinen <juho.saarinen@gmail.com>",
     "Tom Howard <tom@windyroad.com.au>",
     "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4505,10 +4505,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-projen@^0.58.15:
-  version "0.58.15"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.58.15.tgz#37640b839c2af5d03dcfe276f25b9988d84308ab"
-  integrity sha512-js9tdlmyUqPdz46BDYcdCrN936Gcr8ndnjX0J5aYVgOxucS1EHWXdLHqAOyhZiuYevpQ2dXg2AYurEdgjRXPtA==
+projen@0.58.16:
+  version "0.58.16"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.58.16.tgz#327f80152dbc9c47d067357a37860006c62b989c"
+  integrity sha512-5xguZ8fUnX9EYcFovTWlwZJmN/1xKO2RcfWo5g3bLueqID76VRk9mk/C8Q0Nta1Axstf4vTFM0rhFckA6q2nQw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -5188,10 +5188,10 @@ ts-node@^10.7.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-ts-node@^10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.0.tgz#3ceb5ac3e67ae8025c1950626aafbdecb55d82ce"
-  integrity sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==
+ts-node@^10.8.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
@@ -5296,7 +5296,12 @@ typedoc@*:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@^4.4.3, typescript@^4.6.4:
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^4.4.3:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==


### PR DESCRIPTION
Allow all newer versions than one used in dev

Locked typescript version to one supported by used linter

Allows to remove workaround ``project.package.addPackageResolutions(`projen@${projenVersion}`);`` from `.projenrc.js`.